### PR TITLE
fix: skip type cells when issuing UDT

### DIFF
--- a/framework/helper/contract.py
+++ b/framework/helper/contract.py
@@ -177,10 +177,7 @@ def invoke_ckb_contract(
         }
 
         input_cell_cap += (
-            float(
-                live_cell["capacity"].replace("(CKB)", "").strip()
-            )
-            * 100000000
+            float(live_cell["capacity"].replace("(CKB)", "").strip()) * 100000000
         )
 
         input_cell_out_points.append(input_cell_out_point)

--- a/framework/helper/contract.py
+++ b/framework/helper/contract.py
@@ -114,6 +114,7 @@ def invoke_ckb_contract(
     cell_deps=[],
     input_cells=[],
     output_lock_arg="0x470dcdc5e44064909650113a274b3b36aecb6dc7",
+    skip_type_cells=False,
 ):
     """
 
@@ -126,6 +127,8 @@ def invoke_ckb_contract(
         data:
         fee:
         api_url:
+        skip_type_cells: Exclude live cells with a type script from automatic
+            capacity input selection. Explicit ``input_cells`` are unchanged.
 
     Returns:
 
@@ -161,20 +164,21 @@ def invoke_ckb_contract(
     input_cells_hashes = [input_cell["tx_hash"] for input_cell in input_cells]
 
     for i in range(len(account_live_cells["live_cells"])):
-        if account_live_cells["live_cells"][i]["tx_hash"] in input_cells_hashes:
+        live_cell = account_live_cells["live_cells"][i]
+        if live_cell["tx_hash"] in input_cells_hashes:
+            continue
+        if skip_type_cells and live_cell.get("type_hashes") is not None:
             continue
         if input_cell_cap > 20000000000:
             break
         input_cell_out_point = {
-            "tx_hash": account_live_cells["live_cells"][i]["tx_hash"],
-            "index": account_live_cells["live_cells"][i]["output_index"],
+            "tx_hash": live_cell["tx_hash"],
+            "index": live_cell["output_index"],
         }
 
         input_cell_cap += (
             float(
-                account_live_cells["live_cells"][i]["capacity"]
-                .replace("(CKB)", "")
-                .strip()
+                live_cell["capacity"].replace("(CKB)", "").strip()
             )
             * 100000000
         )

--- a/framework/helper/udt_contract.py
+++ b/framework/helper/udt_contract.py
@@ -127,5 +127,6 @@ def issue_udt_tx(udt_contract, rpc_url, owner_private, account_private, amount):
         cell_deps=[],
         input_cells=[],
         output_lock_arg=account1["lock_arg"],
+        skip_type_cells=True,
     )
     return tx_hash


### PR DESCRIPTION
## Summary

- add an opt-in `skip_type_cells` selector to `invoke_ckb_contract`
- enable it for `issue_udt_tx` so faucet/mint transactions use only pure CKB cells for automatic capacity inputs

## Root cause

The generic capacity selector could consume an existing xUDT cell without recreating its matching UDT change output. With near-`u128::MAX` balances, xUDT verification then failed with `ERROR_OVERFLOWING` (`-51`).

## Validation

- `python3 -m py_compile framework/helper/contract.py framework/helper/udt_contract.py`
- `pytest test_cases/fiber/devnet/open_channel/test_funding_udt_type_script.py::TestFundingUdtTypeScript::test_node1_add_node2_amount_gt_u128_max -v -s`
